### PR TITLE
Add query "newer" to /api/items/get

### DIFF
--- a/pr0gramm.postman_collection.json
+++ b/pr0gramm.postman_collection.json
@@ -581,6 +581,12 @@
 									"disabled": true
 								},
 								{
+									"key": "newer",
+									"value": "3261814",
+									"description": "Neuer als Post-ID",
+									"disabled": true
+								},
+								{
 									"key": "flags",
 									"value": "15",
 									"description": "9 = SFW, 2 = NSFW, 4 = NSFL = 4 // ADDIEREN",


### PR DESCRIPTION
"Newer" was missing in the documentation.

Example: https://pr0gramm.com/api/items/get?id=99&flags=15&newer=99

This can be used to prevent older posts from being queried